### PR TITLE
Fix Incorrect Humanoid File Paths in Tests to Resolve FileNotFoundError

### DIFF
--- a/.github/actions/install_ubuntu_deps/action.yml
+++ b/.github/actions/install_ubuntu_deps/action.yml
@@ -54,7 +54,7 @@ runs:
   - name: Install conda dependencies
     run: |-
       echo "Install conda and dependencies"
-      conda install -q -y mkl==2021.4.0
+      conda install -q -y mkl==2023.1.0
       conda install -q -y -c conda-forge ninja ccache
       conda install -q -y -c conda-forge libglib=2.76.1 glib=2.76.1 glib-tools=2.76.1
       conda install -y -c conda-forge numpy==1.26.4 pytest pytest-cov hypothesis pytest-mock

--- a/.github/actions/install_ubuntu_deps/action.yml
+++ b/.github/actions/install_ubuntu_deps/action.yml
@@ -54,7 +54,7 @@ runs:
   - name: Install conda dependencies
     run: |-
       echo "Install conda and dependencies"
-      conda install -q -y mkl==2022.1.0
+      conda install -q -y mkl==2023.1.0
       conda install -q -y -c conda-forge ninja ccache
       conda install -q -y -c conda-forge libglib=2.76.1 glib=2.76.1 glib-tools=2.76.1
       conda install -y -c conda-forge numpy==1.26.4 pytest pytest-cov hypothesis pytest-mock

--- a/.github/actions/install_ubuntu_deps/action.yml
+++ b/.github/actions/install_ubuntu_deps/action.yml
@@ -54,7 +54,7 @@ runs:
   - name: Install conda dependencies
     run: |-
       echo "Install conda and dependencies"
-      conda install -q -y mkl==2023.1.0
+      conda install -q -y mkl==2022.1.0
       conda install -q -y -c conda-forge ninja ccache
       conda install -q -y -c conda-forge libglib=2.76.1 glib=2.76.1 glib-tools=2.76.1
       conda install -y -c conda-forge numpy==1.26.4 pytest pytest-cov hypothesis pytest-mock

--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -96,8 +96,7 @@ jobs:
         git lfs install
 
         # get the standard test assets from the downloader
-        python -m habitat_sim.utils.datasets_download --uids ci_test_assets hab_spot_arm rearrange_task_assets hab3_bench_assets partnr_episodes_ci hssd_partnr_ci --data-path data/ --no-replace --no-prune
-        git clone https://huggingface.co/datasets/ai-habitat/OVMM_objects data/objects_ovmm --recursive
+        python -m habitat_sim.utils.datasets_download --uids ci_test_assets hab_spot_arm rearrange_task_assets hab3_bench_assets partnr_episodes_ci hssd_partnr_ci ovmm_objects --data-path data/ --no-replace --no-prune
         ln -s versioned_data/hab3_bench_assets/humanoids/ data/humanoids
         ln -s versioned_data/ovmm_objects/ data/objects_ovmm
 

--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -96,7 +96,8 @@ jobs:
         git lfs install
 
         # get the standard test assets from the downloader
-        python -m habitat_sim.utils.datasets_download --uids ci_test_assets hab_spot_arm rearrange_task_assets hab3_bench_assets partnr_episodes_ci hssd_partnr_ci ovmm_objects --data-path data/ --no-replace --no-prune
+        python -m habitat_sim.utils.datasets_download --uids ci_test_assets hab_spot_arm rearrange_task_assets hab3_bench_assets partnr_episodes_ci hssd_partnr_ci --data-path data/ --no-replace --no-prune
+        git clone https://huggingface.co/datasets/ai-habitat/OVMM_objects data/objects_ovmm --recursive
         ln -s versioned_data/hab3_bench_assets/humanoids/ data/humanoids
         ln -s versioned_data/ovmm_objects/ data/objects_ovmm
 

--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -135,7 +135,10 @@ jobs:
         export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
         conda activate partnr
         cd partnr-planner
-        python -m pytest -s habitat_llm/tests
+        for test_file in habitat_llm/tests/*.py; do
+            echo ">>> Running test: $test_file"
+            python -m pytest -s "$test_file"
+        done
         python -m pytest dataset_generation/tests
     #NOTE: use the below to debug with ssh: simply move this "job" just before the crashing job to intercept the workflow
     #- name: Debugging with tmate

--- a/habitat_llm/tests/test_constrained_generation.py
+++ b/habitat_llm/tests/test_constrained_generation.py
@@ -23,8 +23,8 @@ DATASET_OVERRIDES = [
     "habitat.dataset.scenes_dir=data/hssd-partnr-ci",
     "+habitat.dataset.metadata.metadata_folder=data/hssd-partnr-ci/metadata",
     "habitat.environment.iterator_options.shuffle=False",
-    "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/female_0/female_0.urdf",  # We change the config to human 0 since only human 0 in the CI testing dataset
-    "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/female_0/female_0_motion_data_smplx.pkl",  # We change the config to human 0 since only human 0 in the CI testing dataset
+    "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/humanoid_data/female_0/female_0.urdf",  # We change the config to human 0 since only human 0 in the CI testing dataset
+    "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/humanoid_data/female_0/female_0_motion_data_smplx.pkl",  # We change the config to human 0 since only human 0 in the CI testing dataset
 ]
 
 

--- a/habitat_llm/tests/test_planner.py
+++ b/habitat_llm/tests/test_planner.py
@@ -37,8 +37,8 @@ DATASET_OVERRIDES = [
     "habitat.dataset.scenes_dir=data/hssd-partnr-ci",
     "+habitat.dataset.metadata.metadata_folder=data/hssd-partnr-ci/metadata",
     "habitat.environment.iterator_options.shuffle=False",
-    "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/female_0/female_0.urdf",  # We change the config to human 0 since only human 0 in the CI testing dataset
-    "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/female_0/female_0_motion_data_smplx.pkl",  # We change the config to human 0 since only human 0 in the CI testing dataset
+    "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/humanoid_data/female_0/female_0.urdf",  # We change the config to human 0 since only human 0 in the CI testing dataset
+    "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/humanoid_data/female_0/female_0_motion_data_smplx.pkl",  # We change the config to human 0 since only human 0 in the CI testing dataset
 ]
 
 

--- a/habitat_llm/tests/test_skills.py
+++ b/habitat_llm/tests/test_skills.py
@@ -253,8 +253,8 @@ def test_neural_network_and_oracle_skills(skill_config):
                 f"evaluation={skill_config}",  # We test neural network/oracle skills
                 "device=cpu",  # We test cpu version of the skills
                 "habitat_conf/task=rearrange_easy_multi_agent_nn",  # We use the action space for nn skills
-                "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/female_0/female_0.urdf",  # We change the config to human 0 since only human 0 in the CI testing dataset
-                "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/female_0/female_0_motion_data_smplx.pkl",  # We change the config to human 0 since only human 0 in the CI testing dataset
+                "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/humanoid_data/female_0/female_0.urdf",  # We change the config to human 0 since only human 0 in the CI testing dataset
+                "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/humanoid_data/female_0/female_0_motion_data_smplx.pkl",  # We change the config to human 0 since only human 0 in the CI testing dataset
                 "habitat.dataset.data_path=data/datasets/partnr_episodes/v0_0/ci.json.gz",  # We test with a specific dataset
                 "habitat.dataset.scenes_dir=data/hssd-partnr-ci",
                 "+habitat.dataset.metadata.metadata_folder=data/hssd-partnr-ci/metadata",
@@ -379,8 +379,8 @@ def test_object_state_skills(skill_config):
                 f"evaluation={skill_config}",
                 "device=cpu",
                 "habitat_conf/task=rearrange_easy_multi_agent_nn",
-                "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/female_0/female_0.urdf",  # We change the config to human 0 since only human 0 in the CI testing dataset
-                "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/female_0/female_0_motion_data_smplx.pkl",  # We change the config to human 0 since only human 0 in the CI testing dataset
+                "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/humanoid_data/female_0/female_0.urdf",  # We change the config to human 0 since only human 0 in the CI testing dataset
+                "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/humanoid_data/female_0/female_0_motion_data_smplx.pkl",  # We change the config to human 0 since only human 0 in the CI testing dataset
                 "habitat.dataset.data_path=data/datasets/partnr_episodes/v0_0/ci.json.gz",
                 "habitat.dataset.scenes_dir=data/hssd-partnr-ci",
                 "+habitat.dataset.metadata.metadata_folder=data/hssd-partnr-ci/metadata",
@@ -748,8 +748,8 @@ def test_floors(skill_config):
                 f"evaluation={skill_config}",
                 "device=cpu",
                 "habitat_conf/task=rearrange_easy_multi_agent_nn",
-                "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/female_0/female_0.urdf",
-                "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/female_0/female_0_motion_data_smplx.pkl",
+                "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/humanoid_data/female_0/female_0.urdf",
+                "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/humanoid_data/female_0/female_0_motion_data_smplx.pkl",
                 "habitat.dataset.data_path=data/datasets/partnr_episodes/v0_0/ci.json.gz",
                 "habitat.dataset.scenes_dir=data/hssd-partnr-ci",
                 "+habitat.dataset.metadata.metadata_folder=data/hssd-partnr-ci/metadata",
@@ -859,8 +859,8 @@ def test_oracle_point_skills(skill_config):
                 f"evaluation={skill_config}",
                 "device=cpu",
                 "habitat_conf/task=rearrange_easy_multi_agent_nn",
-                "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/female_0/female_0.urdf",
-                "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/female_0/female_0_motion_data_smplx.pkl",
+                "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/humanoid_data/female_0/female_0.urdf",
+                "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/humanoid_data/female_0/female_0_motion_data_smplx.pkl",
                 "habitat.dataset.data_path=data/datasets/partnr_episodes/v0_0/ci.json.gz",
                 "habitat.dataset.scenes_dir=data/hssd-partnr-ci",
                 "+habitat.dataset.metadata.metadata_folder=data/hssd-partnr-ci/metadata",

--- a/habitat_llm/tests/test_verification.py
+++ b/habitat_llm/tests/test_verification.py
@@ -20,8 +20,8 @@ DATASET_OVERRIDES = [
     "habitat.dataset.scenes_dir=data/hssd-partnr-ci",
     "+habitat.dataset.metadata.metadata_folder=data/hssd-partnr-ci/metadata",
     "habitat.environment.iterator_options.shuffle=False",
-    "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/female_0/female_0.urdf",  # We change the config to human 0 since only human 0 in the CI testing dataset
-    "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/female_0/female_0_motion_data_smplx.pkl",  # We change the config to human 0 since only human 0 in the CI testing dataset
+    "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/humanoid_data/female_0/female_0.urdf",  # We change the config to human 0 since only human 0 in the CI testing dataset
+    "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/humanoid_data/female_0/female_0_motion_data_smplx.pkl",  # We change the config to human 0 since only human 0 in the CI testing dataset
 ]
 
 

--- a/habitat_llm/tests/test_world_graph.py
+++ b/habitat_llm/tests/test_world_graph.py
@@ -31,8 +31,8 @@ DATASET_OVERRIDES = [
     "habitat.dataset.scenes_dir=data/hssd-partnr-ci",
     "+habitat.dataset.metadata.metadata_folder=data/hssd-partnr-ci/metadata",
     "habitat.environment.iterator_options.shuffle=False",
-    "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/female_0/female_0.urdf",  # We change the config to human 0 since only human 0 in the CI testing dataset
-    "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/female_0/female_0_motion_data_smplx.pkl",  # We change the config to human 0 since only human 0 in the CI testing dataset
+    "habitat.simulator.agents.agent_1.articulated_agent_urdf=data/humanoids/humanoid_data/female_0/female_0.urdf",  # We change the config to human 0 since only human 0 in the CI testing dataset
+    "habitat.simulator.agents.agent_1.motion_data_path=data/humanoids/humanoid_data/female_0/female_0_motion_data_smplx.pkl",  # We change the config to human 0 since only human 0 in the CI testing dataset
 ]
 
 


### PR DESCRIPTION
## Motivation and Context

The tests were referencing outdated humanoid file paths, which led to a FileNotFoundError during execution. Specifically, the tests used the path:  
`data/humanoids/female_0/female_0_motion_data_smplx.pkl`  
instead of the correct path:  
`data/humanoids/humanoid_data/female_0/female_0_motion_data_smplx.pkl`.

This change is required to align the test configurations with the actual dataset structure as defined in Habitat-Sim's dataset download utility ([reference](https://github.com/facebookresearch/habitat-sim/blob/2aa5ed12c639e02dc19ea3b5fd2df7763ef176af/src_python/habitat_sim/utils/datasets_download.py#L193)). 
The issue was originally reported in #4 

---

## How Has This Been Tested

- **Local Testing:** All tests have been executed locally and have passed.
- **CI Testing:** Although local tests passed, CI tests should be run to ensure full compatibility across different environments.

---

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## Checklist

- [x] My code follows the code style of this project.  
- [ ] My change requires a change to the documentation.  
- [ ] I have updated the documentation accordingly.  
- [ ] I have added tests to cover my changes.  
- [x] All new and existing tests passed.

Please review the changes and run the CI tests to confirm everything is working as expected.